### PR TITLE
Add fragment more -> Add new fragment more

### DIFF
--- a/app/src/main/java/com/antosik/benchproject/app/more/view/MoreFragment.kt
+++ b/app/src/main/java/com/antosik/benchproject/app/more/view/MoreFragment.kt
@@ -1,0 +1,18 @@
+package com.antosik.benchproject.app.more.view
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.ViewGroup
+import androidx.fragment.app.Fragment
+import com.antosik.benchproject.databinding.MoreFragmentBinding
+import dagger.hilt.android.AndroidEntryPoint
+
+@AndroidEntryPoint
+class MoreFragment : Fragment() {
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ) = MoreFragmentBinding.inflate(inflater, container, false).root
+}

--- a/app/src/main/res/layout/more_fragment.xml
+++ b/app/src/main/res/layout/more_fragment.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        tools:context=".app.more.view.MoreFragment">
+
+        <TextView
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:text="@string/moreFragmentLabel" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -16,4 +16,5 @@
     <string name="releaseDateLabel">Release Date</string>
     <string name="genresLabel">Genres</string>
     <string name="emptyDatabaseText">I have no data to show</string>
+    <string name="moreFragmentLabel">More</string>
 </resources>


### PR DESCRIPTION
I would like to add a third option in the bottom navigation with the name `More`. This fragment will be a container for other information like a short description about this app and adding a button with oss-licenses and in the future maybe for something else.