### PR TITLE
Deprecated elements -> Remove singleLine from project

### DIFF
--- a/app/src/main/res/layout/movie_details_data.xml
+++ b/app/src/main/res/layout/movie_details_data.xml
@@ -30,8 +30,7 @@
             android:layout_gravity="center"
             android:layout_marginStart="5dp"
             android:layout_marginEnd="5dp"
-            app:genresChips="@{viewModel.responseMovieDetails.genres}"
-            app:singleLine="false" />
+            app:genresChips="@{viewModel.responseMovieDetails.genres}" />
 
         <TextView
             android:id="@+id/movieDetailsDescriptionLabel"

--- a/app/src/main/res/layout/popular_movie_recycler_item_layout.xml
+++ b/app/src/main/res/layout/popular_movie_recycler_item_layout.xml
@@ -58,7 +58,7 @@
                 android:layout_marginTop="10dp"
                 android:layout_marginEnd="6dp"
                 android:ellipsize="end"
-                android:singleLine="true"
+                android:maxLines="1"
                 android:text="@{movie.name}"
                 android:textSize="20sp"
                 android:textStyle="bold"


### PR DESCRIPTION
I shouldn't use singleLine [link to documentation](https://developer.android.com/reference/android/R.attr#singleLine).
Explanation:
_**This constant was deprecated in API level 15.**
This attribute is deprecated. Use maxLines instead to change the layout of a static text, and use the textMultiLine flag in the inputType attribute instead for editable text views (if both singleLine and inputType are supplied, the inputType flags will override the value of singleLine)._